### PR TITLE
エラー処理を修正

### DIFF
--- a/js/packages/cli/src/commands/upload-coinfra.ts
+++ b/js/packages/cli/src/commands/upload-coinfra.ts
@@ -227,7 +227,7 @@ export async function uploadCoinfra({
             signedTransaction: signedTransactions[i],
           });
         } catch (e) {
-          console.log('Caught failure', e);
+          throw new Error(`Caught failure ${e}`);
         }
       }
     } catch (error) {


### PR DESCRIPTION
sendSignedTransactionでエラーが投げられた場合に処理がsuccessになってしまう不具合を修正